### PR TITLE
[cherry-pick][branch-1.0] Add max_concurrent_writes configuration to control the max write procedure in parallel

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -24,6 +24,9 @@ DEFINE_uint64(block_file_size, 10737418240,
 DEFINE_bool(pre_allocate_block_file, false, "Whether to pre-allocate the the block file to the target size");
 DEFINE_bool(enable_disk_checksum, true, "Whether to do checksum to check the data correctness read from disk");
 
+DEFINE_uint64(max_concurrent_writes, 1500000,
+              "The maximum concurrent write count, to avoid too many writes that affect write latency");
+
 DEFINE_uint32(mem_evict_times, 2, "The times of target size that need to be evicted in an memery eviction");
 DEFINE_uint32(disk_evict_times, 2, "The times of target size that need to be evicted in a disk eviction");
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -25,6 +25,8 @@ DECLARE_uint64(block_file_size);
 DECLARE_bool(pre_allocate_block_file);
 DECLARE_bool(enable_disk_checksum);
 
+DECLARE_uint64(max_concurrent_writes);
+
 DECLARE_uint32(mem_evict_times);
 DECLARE_uint32(disk_evict_times);
 

--- a/src/disk_cache.cpp
+++ b/src/disk_cache.cpp
@@ -160,4 +160,13 @@ size_t DiskCache::used_bytes() const {
     return _space_manager->used_bytes();
 }
 
+std::vector<DirSpace> DiskCache::dir_spaces() const {
+    auto& cache_dirs = _space_manager->cache_dirs();
+    std::vector<DirSpace> spaces;
+    for (auto& dir : cache_dirs) {
+        spaces.push_back({.path = dir->path(), .quota_bytes = dir->quota_bytes()});
+    }
+    return spaces;
+}
+
 } // namespace starrocks::starcache

--- a/src/disk_cache.h
+++ b/src/disk_cache.h
@@ -81,6 +81,9 @@ public:
     // Get the disk cache usage (in bytes)
     size_t used_bytes() const;
 
+    // Get the disk spaces
+    std::vector<DirSpace> dir_spaces() const;
+
 private:
     void _update_block_checksum(DiskBlockPtr block, const BlockSegment& segment) const;
 

--- a/src/disk_space_manager.h
+++ b/src/disk_space_manager.h
@@ -132,6 +132,8 @@ public:
 
     size_t used_bytes() const { return _used_bytes; }
 
+    std::vector<CacheDirPtr>& cache_dirs() { return _cache_dirs; }
+
     void reset() {
         _quota_bytes = 0;
         _used_bytes = 0;

--- a/src/star_cache.cpp
+++ b/src/star_cache.cpp
@@ -22,6 +22,10 @@ StarCache::StarCache() {
     _cache_impl = new StarCacheImpl;
 }
 
+const CacheOptions* StarCache::options() {
+    return _cache_impl->options();
+}
+
 StarCache::~StarCache() {
     delete _cache_impl;
 }

--- a/src/star_cache.h
+++ b/src/star_cache.h
@@ -27,6 +27,9 @@ public:
     // Init the starcache instance with given options
     Status init(const CacheOptions& options);
 
+    // Get the starcache options
+    const CacheOptions* options();
+
     // Set the whole cache object.
     // If the `cache_key` exists, replace the cache data.
     // If the `ttl_seconds` is 0 (default), no ttl restriction will be set.

--- a/src/star_cache_impl.cpp
+++ b/src/star_cache_impl.cpp
@@ -77,6 +77,12 @@ Status StarCacheImpl::set(const CacheKey& cache_key, const IOBuf& buf, uint64_t 
         return Status(E_INTERNAL, "cache value should not be empty");
     }
 
+    auto counter_guard = _concurrent_writes_test();
+    if (!counter_guard) {
+        LOG(WARNING) << "the concurrent write size exceeds the maximum threshold, reject it";
+        return Status(EBUSY, "the cache system is busy now");
+    }
+
     CacheId cache_id = cachekey2id(cache_key);
     CacheItemPtr cache_item = _access_index->find(cache_id);
     if (cache_item) {
@@ -309,7 +315,7 @@ void StarCacheImpl::_remove_cache_item(const CacheId& cache_id, CacheItemPtr cac
 
 Status StarCacheImpl::_flush_block(CacheItemPtr cache_item, const BlockKey& block_key) {
     if (cache_item->is_released()) {
-        LOG(INFO) << "The block to flush is released, key: " << block_key;
+        LOG(INFO) << "the block to flush is released, key: " << block_key;
         return Status::OK();
     }
     // Hold the handle, in case that the disk cache item be evicted during the flush process
@@ -352,6 +358,13 @@ Status StarCacheImpl::_flush_block(CacheItemPtr cache_item, const BlockKey& bloc
         _remove_cache_item(block_key.cache_id, cache_item);
     }
     return Status::OK();
+}
+
+StarCacheImpl::IOCounterGuard StarCacheImpl::_concurrent_writes_test() {
+    if (UNLIKELY(_concurrent_writes + 1 > config::FLAGS_max_concurrent_writes)) {
+        return nullptr;
+    }
+    return std::make_shared<IOCounter>(_concurrent_writes, 1);
 }
 
 size_t StarCacheImpl::_continuous_segments_size(const std::vector<BlockSegmentPtr>& segments) {

--- a/src/star_cache_impl.cpp
+++ b/src/star_cache_impl.cpp
@@ -40,10 +40,13 @@ StarCacheImpl::~StarCacheImpl() {
 }
 
 Status StarCacheImpl::init(const CacheOptions& options) {
-    config::FLAGS_enable_disk_checksum = options.checksum;
+    _options = options;
     if (options.block_size > 0) {
         config::FLAGS_block_size = options.block_size;
+    } else {
+        _options.block_size = config::FLAGS_block_size;
     }
+    config::FLAGS_enable_disk_checksum = options.checksum;
 
     MemCacheOptions mc_options;
     mc_options.mem_quota_bytes = options.mem_quota_bytes;
@@ -69,6 +72,10 @@ Status StarCacheImpl::init(const CacheOptions& options) {
               << ", disk checksum: " << config::FLAGS_enable_disk_checksum
               << ", mem_quota: " << _mem_cache->quota_bytes() << ", disk_quota: " << _disk_cache->quota_bytes();
     return Status::OK();
+}
+
+const CacheOptions* StarCacheImpl::options() {
+    return &_options;
 }
 
 Status StarCacheImpl::set(const CacheKey& cache_key, const IOBuf& buf, uint64_t ttl_seconds) {

--- a/src/star_cache_impl.h
+++ b/src/star_cache_impl.h
@@ -30,6 +30,8 @@ public:
 
     Status init(const CacheOptions& options);
 
+    const CacheOptions* options();
+
     Status set(const std::string& cache_key, const IOBuf& buf, uint64_t ttl_seconds);
 
     Status get(const std::string& cache_key, IOBuf* buf);
@@ -80,6 +82,7 @@ private:
     BlockSegmentPtr _alloc_block_segment(const BlockKey& block_key, off_t offset, uint32_t size, const IOBuf& buf);
     DiskBlockPtr _alloc_disk_block(const BlockKey& block_key);
 
+    CacheOptions _options;
     std::unique_ptr<MemCache> _mem_cache = nullptr;
     std::unique_ptr<DiskCache> _disk_cache = nullptr;
     AccessIndex* _access_index = nullptr;


### PR DESCRIPTION
Add max_concurrent_writes configuration to control the max write procedure in parallel, to avoid heavy write procudure that affect read and write latency.

(cherry picked from #10 )