### PR TITLE
[Enhancement] Optimize the gcc and cmake environment variables in build scripts.

### DIFF
--- a/build-scripts/cmake-build.sh
+++ b/build-scripts/cmake-build.sh
@@ -83,28 +83,26 @@ echo "Get params:
 "
 
 # GCC is needed anyway even with clang
-if [ -z "$GCC_INSTALL_DIR" ] ; then
-    if [ -n "$STARCACHE_GCC_HOME" ] ; then
-        # reuse STARCACHE_GCC_HOME environment variable if available
-        export GCC_INSTALL_DIR=$STARCACHE_GCC_HOME
-    fi
-fi
-
-# check again
-if [ -z "$GCC_INSTALL_DIR" ] ; then
-    echo "Please set GCC_INSTALL_DIR to compiler install path"
-    exit 1
+if [ -z "${STARCACHE_GCC_HOME}" ] ; then
+    export STARCACHE_GCC_HOME=$(dirname `which gcc`)/..
 fi
 
 if [[ -z "$CC" || -z "$CXX" ]] ; then
-    which_gcc=`which gcc &>/dev/null`
-    if [[ -z "$which_gcc" || "$gcc_path" != "$GCC_INSTALL_DIR/bin/gcc" ]] ; then
+    gcc_path=`which gcc 2>/dev/null`
+    if [[ -n "${STARCACHE_GCC_HOME}" && "$gcc_path" != "${STARCACHE_GCC_HOME}/bin/gcc"  ]] ; then
         # ensure get the right gcc/g++
-        export PATH=$GCC_INSTALL_DIR/bin:$PATH
+        export PATH=${STARCACHE_GCC_HOME}/bin:$PATH
+        export LD_LIBRARY_PATH="${STARCACHE_GCC_HOME}/lib:$STARCACHE_GCC_HOME/lib64:$LD_LIBRARY_PATH"
     fi
     # force cmake use gcc/g++ instead of default cc/c++
     export CC=gcc
     export CXX=g++
+fi
+
+if [ -n "${STARCACHE_CMAKE_HOME}" ] ; then
+    export PATH=${STARCACHE_CMAKE_HOME}/bin:$PATH
+    echo "cmake version: $(cmake --version)"
+    echo "cmake path: $(which cmake)"
 fi
 
 if [ -z "${INSTALL_DIR_PREFIX}" ]; then
@@ -133,8 +131,6 @@ else
     THIRD_PARTY_INSTALL_PREFIX=${STARCACHE_THIRDPARTY}
 fi
 
-export LD_LIBRARY_PATH="$GCC_INSTALL_DIR/lib:$GCC_INSTALL_DIR/lib64:$LD_LIBRARY_PATH"
-
 PARALLEL=${PARALLEL:-$[$(nproc)/4+1]}
 
 # external depdendencies should be added to third-party/build-thirdparty.sh
@@ -145,18 +141,18 @@ INSTALL_DIR_PREFIX=$THIRD_PARTY_INSTALL_PREFIX ./build-thirdparty.sh || exit 1
 INSTALL_DIR_PREFIX=$OLD_INSTALL_DIR_PREFIX
 popd
 
-CMAKE_BUILD_DIR=build/build_${CMAKE_BUILD_TYPE}
+CMAKE_BUILD_DIR=${STARCACHE_HOME}/build/build_${CMAKE_BUILD_TYPE}
 
 if [ -z "${STARCACHE_INSTALL_DIR}" ] ; then
     STARCACHE_INSTALL_DIR=$INSTALL_DIR_PREFIX/starcache_installed
 fi
 
-mkdir -p ${CMAKE_BUILD_DIR}
-mkdir -p ${STARCACHE_INSTALL_DIR}
-
 if [ ${CLEAN} -eq 1  ]; then
     rm -rf ${CMAKE_BUILD_DIR}
 fi
+
+mkdir -p ${CMAKE_BUILD_DIR}
+mkdir -p ${STARCACHE_INSTALL_DIR}
 
 cmake -B ${CMAKE_BUILD_DIR} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache                                \
 	  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} 													\

--- a/test/star_cache_test.cpp
+++ b/test/star_cache_test.cpp
@@ -278,7 +278,6 @@ TEST_F(StarCacheTest, disk_cache_eviction) {
         IOBuf expect_buf = gen_iobuf(obj_size, ch);
         IOBuf buf;
         st = cache->get(cache_key + std::to_string(i), &buf);
-        LOG(INFO) << "[Gavin] get cache key: " << cache_key << i << ", st: " << st.error_str();
         if (exist_index.find(i) != exist_index.end()) {
             ASSERT_TRUE(st.ok()) << st.error_str();
             ASSERT_EQ(buf, expect_buf);


### PR DESCRIPTION
Optimize the gcc and cmake environment variables in build scripts to facilitate external input at compile time. For example, we can pass our own gcc and cmake home to the build scripts.