### PR TITLE
 [Enhancement] Add `STARCACHE_CMAKE_CMD` parameter to build scripts

### DIFF
--- a/build-scripts/cmake-build.sh
+++ b/build-scripts/cmake-build.sh
@@ -99,11 +99,15 @@ if [[ -z "$CC" || -z "$CXX" ]] ; then
     export CXX=g++
 fi
 
-if [ -n "${STARCACHE_CMAKE_HOME}" ] ; then
-    export PATH=${STARCACHE_CMAKE_HOME}/bin:$PATH
-    echo "cmake version: $(cmake --version)"
-    echo "cmake path: $(which cmake)"
+if [ -z "${STARCACHE_CMAKE_CMD}" ]; then
+    if [ -n "${STARCACHE_CMAKE_HOME}" ] ; then
+        export PATH=${STARCACHE_CMAKE_HOME}/bin:$PATH
+    fi
+    export STARCACHE_CMAKE_CMD=cmake
 fi
+
+echo "STARCACHE_CMAKE_CMD path: ${STARCACHE_CMAKE_CMD}"
+echo "STARCACHE_CMAKE_CMD version: `${STARCACHE_CMAKE_CMD} --version`"
 
 if [ -z "${INSTALL_DIR_PREFIX}" ]; then
     INSTALL_DIR_PREFIX=${STARCACHE_HOME}/third_party/installed
@@ -154,7 +158,7 @@ fi
 mkdir -p ${CMAKE_BUILD_DIR}
 mkdir -p ${STARCACHE_INSTALL_DIR}
 
-cmake -B ${CMAKE_BUILD_DIR} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache                                \
+$STARCACHE_CMAKE_CMD -B ${CMAKE_BUILD_DIR} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache                                \
 	  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} 													\
 	  -DWITH_TESTS=${WITH_TESTS} 																\
 	  -DWITH_TOOLS=${WITH_TOOLS} 																\

--- a/third_party/build-thirdparty.sh
+++ b/third_party/build-thirdparty.sh
@@ -31,7 +31,12 @@ mkdir -p $TP_INSTALL_DIR/include
 mkdir -p $TP_INSTALL_DIR/lib
 
 BUILD_SYSTEM=${BUILD_SYSTEM:-make}
-CMAKE_CMD=cmake
+if [ -z "${STARCACHE_CMAKE_CMD}" ]; then
+    if [ -n "${STARCACHE_CMAKE_HOME}" ] ; then
+        export PATH=${STARCACHE_CMAKE_HOME}/bin:$PATH
+    fi
+    export STARCACHE_CMAKE_CMD=cmake
+fi
 CMAKE_GENERATOR="Unix Makefiles"
 
 export CXXFLAGS="-O3 -fno-omit-frame-pointer -Wno-class-memaccess -fPIC -g -I${TP_INCLUDE_DIR}"
@@ -308,8 +313,8 @@ cmake_build()
         build_dir=tmp-build
     fi
     rm -rf $build_dir/ CMakeCache.txt
-    echo $CMAKE_CMD $srcdir -B $build_dir -G "${CMAKE_GENERATOR}" $common_opts "$@"
-    $CMAKE_CMD $srcdir -B $build_dir -G "${CMAKE_GENERATOR}" $common_opts "$@"
+    echo $STARCACHE_CMAKE_CMD $srcdir -B $build_dir -G "${CMAKE_GENERATOR}" $common_opts "$@"
+    $STARCACHE_CMAKE_CMD $srcdir -B $build_dir -G "${CMAKE_GENERATOR}" $common_opts "$@"
 
     pushd $build_dir &>/dev/null
     ${BUILD_SYSTEM} -j$PARALLEL


### PR DESCRIPTION
Add `STARCACHE_CMAKE_CMD` parameter to build scripts to allow passing a custom cmake binary when building.