### PR TITLE
[Feature] Support pin and unpin api to control some cache behavior.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 code-format/__pycache__/
 third_party/installed/
 third_party/src/
+.ycm_extra_conf.py
 
 # VIM: Swap-files
 [._]*.s[a-w][a-z]

--- a/src/size_based_admission_policy.cpp
+++ b/src/size_based_admission_policy.cpp
@@ -25,10 +25,6 @@ SizeBasedAdmissionPolicy::SizeBasedAdmissionPolicy(const Config& config)
           _rand_generator(std::rand()) {}
 
 BlockAdmission SizeBasedAdmissionPolicy::check_admission(const CacheItemPtr& cache_item, const BlockKey& block_key) {
-    STATIC_EXCEPT_UT size_t disk_quota = DiskSpaceManager::GetInstance()->quota_bytes();
-    if (disk_quota == 0) {
-        return BlockAdmission::DELETE;
-    }
     if (cache_item->size >= _max_check_size) {
         return BlockAdmission::FLUSH;
     }

--- a/src/star_cache.cpp
+++ b/src/star_cache.cpp
@@ -50,4 +50,12 @@ Status StarCache::remove(const CacheKey& cache_key) {
     return _cache_impl->remove(cache_key);
 }
 
+Status StarCache::pin(const std::string& cache_key) {
+    return _cache_impl->pin(cache_key);
+}
+
+Status StarCache::unpin(const std::string& cache_key) {
+    return _cache_impl->unpin(cache_key);
+}
+
 } // namespace starrocks::starcache

--- a/src/star_cache.h
+++ b/src/star_cache.h
@@ -56,11 +56,11 @@ public:
     // The object still can be removed in the cases:
     // 1. calling remove api
     // 2. the ttl is timeout
-    Status pin(const std::string& cache_key) { return Status::OK(); }
+    Status pin(const std::string& cache_key);
 
     // UnPin the cache object in cache.
     // If the object is not exist or has been removed, return ENOENT error.
-    Status unpin(const std::string& cache_key) { return Status::OK(); }
+    Status unpin(const std::string& cache_key);
 
 private:
     StarCacheImpl* _cache_impl = nullptr;

--- a/src/star_cache_impl.h
+++ b/src/star_cache_impl.h
@@ -40,28 +40,24 @@ public:
 
     Status remove(const std::string& cache_key);
 
+    Status pin(const std::string& cache_key);
+
+    Status unpin(const std::string& cache_key);
+
+    bool has_disk_layer() {
+        STATIC_EXCEPT_UT bool has_disk = _options.disk_dir_spaces.size() > 0;
+        return has_disk;
+    }
+
 private:
-    struct IOCounter {
-        IOCounter(std::atomic<size_t>& counter, size_t delta_value)
-            : _counter(counter), _delta_value(delta_value) {
-                _counter += delta_value;
-            }
-        ~IOCounter() {
-            _counter -= _delta_value;
-        }
-
-    private:
-        std::atomic<size_t>& _counter;
-        size_t _delta_value = 0;
-    };
-
-    using IOCounterGuard = std::shared_ptr<IOCounter>;
-
-    IOCounterGuard _concurrent_writes_test();
     static size_t _continuous_segments_size(const std::vector<BlockSegmentPtr>& segments);
 
+    Status _write_cache_item(const CacheId& cache_id, const CacheKey& cache_key, const IOBuf& buf,
+                             uint64_t ttl_seconds);
     Status _read_cache_item(const CacheId& cache_id, CacheItemPtr cache_item, off_t offset, size_t size, IOBuf* buf);
     void _remove_cache_item(const CacheId& cache_id, CacheItemPtr cache_item);
+    Status _pin_cache_item(const CacheId& cache_id, CacheItemPtr cache_item);
+    Status _unpin_cache_item(const CacheId& cache_id, CacheItemPtr cache_item);
 
     Status _write_block(CacheItemPtr cache_item, const BlockKey& block_key, const IOBuf& buf);
     Status _read_block(CacheItemPtr cache_item, const BlockKey& block_key, off_t offset, size_t size, IOBuf* buf);


### PR DESCRIPTION
This PR support pin and unpin api.
If an cache object is pinned, it will not be evicted by eviction policies until one of the following cases:
* The cache object is unpinned by the `unpin` api.
* The cache object is removed by the `remove` api. 
* The TTL is timeout (if set).