### PR TITLE
[Enhancement] Add options parameter to read and write api to suport more io options

### DIFF
--- a/src/aux_funcs.h
+++ b/src/aux_funcs.h
@@ -60,6 +60,11 @@ inline int64_t round_up(int64_t value, int64_t factor) {
     return (value + (factor - 1)) / factor * factor;
 }
 
+inline int64_t round_down(int64_t value, int64_t factor) {
+    return (value + (factor - 1)) / factor * factor;
+    return (value / factor) * factor;
+}
+
 inline uint32_t block_slice_count() {
     STATIC_EXCEPT_UT uint32_t slice_count = config::FLAGS_block_size / config::FLAGS_slice_size;
     return slice_count;

--- a/src/capacity_based_promotion_policy.h
+++ b/src/capacity_based_promotion_policy.h
@@ -27,9 +27,10 @@ public:
     explicit CapacityBasedPromotionPolicy(const Config& config);
     ~CapacityBasedPromotionPolicy() override = default;
 
-    BlockLocation check_write(const CacheItemPtr& cache_item, const BlockKey& block_key) override;
+    BlockLocation check_write(const CacheItemPtr& cache_item, const BlockKey& block_key,
+                              const WriteOptions* options) override;
 
-    bool check_promote(const CacheItemPtr& cache_item, const BlockKey& block_key) override;
+    bool check_promote(const CacheItemPtr& cache_item, const BlockKey& block_key, const ReadOptions* options) override;
 
 private:
     // TODO: Monitor disk ioutil or io latency to reject some write requets when disks overload.

--- a/src/eviction_policy.h
+++ b/src/eviction_policy.h
@@ -44,7 +44,7 @@ public:
 
     virtual ~EvictionPolicy() = default;
 
-    // Add the given id to the evict component
+    // Add the given id to the eviction component
     virtual bool add(const T& id, size_t size) = 0;
 
     // Record the hit of the id
@@ -61,10 +61,10 @@ public:
     // Release the item handle returned by touch
     virtual void release(void* hdl) = 0;
 
-    // Remove the given id from the evict component, used for `pin` function.
+    // Remove the given id from the eviction component, used for `pin` function.
     virtual void remove(const T& id) = 0;
 
-    // Clear all items in the evict component
+    // Clear all items in the eviction component
     virtual void clear() = 0;
 };
 

--- a/src/promotion_policy.h
+++ b/src/promotion_policy.h
@@ -41,10 +41,12 @@ public:
     virtual ~PromotionPolicy() = default;
 
     // Check the location to write the given block first time
-    virtual BlockLocation check_write(const CacheItemPtr& cache_item, const BlockKey& block_key) = 0;
+    virtual BlockLocation check_write(const CacheItemPtr& cache_item, const BlockKey& block_key,
+                                      const WriteOptions* options) = 0;
 
     // Check whether to promote the given block
-    virtual bool check_promote(const CacheItemPtr& cache_item, const BlockKey& block_key) = 0;
+    virtual bool check_promote(const CacheItemPtr& cache_item, const BlockKey& block_key,
+                               const ReadOptions* options) = 0;
 };
 
 } // namespace starrocks::starcache

--- a/src/star_cache.cpp
+++ b/src/star_cache.cpp
@@ -34,27 +34,27 @@ Status StarCache::init(const CacheOptions& options) {
     return _cache_impl->init(options);
 }
 
-Status StarCache::set(const CacheKey& cache_key, const IOBuf& buf, uint64_t ttl_seconds) {
-    return _cache_impl->set(cache_key, buf, ttl_seconds);
+Status StarCache::set(const CacheKey& cache_key, const IOBuf& buf, WriteOptions* options) {
+    return _cache_impl->set(cache_key, buf, options);
 }
 
-Status StarCache::get(const CacheKey& cache_key, IOBuf* buf) {
-    return _cache_impl->get(cache_key, buf);
+Status StarCache::get(const CacheKey& cache_key, IOBuf* buf, ReadOptions* options) {
+    return _cache_impl->get(cache_key, buf, options);
 }
 
-Status StarCache::read(const CacheKey& cache_key, off_t offset, size_t size, IOBuf* buf) {
-    return _cache_impl->read(cache_key, offset, size, buf);
+Status StarCache::read(const CacheKey& cache_key, off_t offset, size_t size, IOBuf* buf, ReadOptions* options) {
+    return _cache_impl->read(cache_key, offset, size, buf, options);
 }
 
 Status StarCache::remove(const CacheKey& cache_key) {
     return _cache_impl->remove(cache_key);
 }
 
-Status StarCache::pin(const std::string& cache_key) {
+Status StarCache::pin(const CacheKey& cache_key) {
     return _cache_impl->pin(cache_key);
 }
 
-Status StarCache::unpin(const std::string& cache_key) {
+Status StarCache::unpin(const CacheKey& cache_key) {
     return _cache_impl->unpin(cache_key);
 }
 

--- a/src/star_cache.h
+++ b/src/star_cache.h
@@ -32,36 +32,38 @@ public:
     const CacheOptions* options();
 
     // Set the whole cache object.
-    // If the `cache_key` exists, replace the cache data.
+    // If the `cache_key` exists:
+    // - if overrite=true, replace the cache data.
+    // - if overrite=false, return EEXIST.
     // If the `ttl_seconds` is 0 (default), no ttl restriction will be set.
-    Status set(const std::string& cache_key, const IOBuf& buf, uint64_t ttl_seconds = 0);
+    Status set(const CacheKey& cache_key, const IOBuf& buf, WriteOptions* options = nullptr);
 
     // Get the whole cache object.
     // If no such object, return ENOENT error
-    Status get(const std::string& cache_key, IOBuf* buf);
+    Status get(const CacheKey& cache_key, IOBuf* buf, ReadOptions* options = nullptr);
 
     // Read the partial cache object with given range.
     // If the range exceeds the object size, only read the range within the object size.
     // Only if all the data in the valid range exists in the cache will it return success, otherwise will return ENOENT.
-    Status read(const std::string& cache_key, off_t offset, size_t size, IOBuf* buf);
+    Status read(const CacheKey& cache_key, off_t offset, size_t size, IOBuf* buf, ReadOptions* options = nullptr);
 
     // Remove the cache object.
     // If no such object, return ENOENT error
-    Status remove(const std::string& cache_key);
+    Status remove(const CacheKey& cache_key);
 
     // Set the cache object ttl.
     // If the `ttl_seconds` is 0, the origin ttl restriction will be removed.
-    Status set_ttl(const std::string& cache_key, uint64_t ttl_seconds) { return Status::OK(); }
+    Status set_ttl(const CacheKey& cache_key, uint64_t ttl_seconds) { return Status::OK(); }
 
     // Pin the cache object in cache.  The cache object will not be evicted by eviction policy.
     // The object still can be removed in the cases:
     // 1. calling remove api
     // 2. the ttl is timeout
-    Status pin(const std::string& cache_key);
+    Status pin(const CacheKey& cache_key);
 
     // UnPin the cache object in cache.
     // If the object is not exist or has been removed, return ENOENT error.
-    Status unpin(const std::string& cache_key);
+    Status unpin(const CacheKey& cache_key);
 
 private:
     StarCacheImpl* _cache_impl = nullptr;

--- a/src/star_cache.h
+++ b/src/star_cache.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "common/config.h"
 #include "common/types.h"
 
 namespace starrocks::starcache {

--- a/src/star_cache_impl.cpp
+++ b/src/star_cache_impl.cpp
@@ -78,8 +78,11 @@ const CacheOptions* StarCacheImpl::options() {
     return &_options;
 }
 
-Status StarCacheImpl::set(const CacheKey& cache_key, const IOBuf& buf, uint64_t ttl_seconds) {
-    STAR_VLOG << "set cache, cache_key: " << cache_key << ", buf size: " << buf.size() << ", ttl: " << ttl_seconds;
+Status StarCacheImpl::set(const CacheKey& cache_key, const IOBuf& buf, WriteOptions* options) {
+    STAR_VLOG << "set cache, cache_key: " << cache_key << ", buf size: " << buf.size();
+    if (options) {
+        STAR_VLOG << " options: " << options;
+    }
     if (buf.empty()) {
         return Status(E_INTERNAL, "cache value should not be empty");
     }
@@ -92,24 +95,34 @@ Status StarCacheImpl::set(const CacheKey& cache_key, const IOBuf& buf, uint64_t 
 
     CacheId cache_id = cachekey2id(cache_key);
     CacheItemPtr cache_item = _access_index->find(cache_id);
+    Status st;
     if (cache_item) {
-        // TODO: Replace the target data directly.
-        STAR_VLOG << "remove old cache for update, cache_key: " << cache_key;
-        _remove_cache_item(cache_id, cache_item);
+        if (!options || options->overrite) {
+            // TODO: Replace the target data directly.
+            STAR_VLOG << "remove old cache for update, cache_key: " << cache_key;
+            _remove_cache_item(cache_id, cache_item);
+        } else {
+            STAR_VLOG << "the cache object already exists, skipped, cache_key: " << cache_key;
+            st.set_error(EEXIST, "the cache object already exists") ;
+        }
     }
-
-    Status st = _write_cache_item(cache_id, cache_key, buf, ttl_seconds);
+    if (st.ok()) {
+        st = _write_cache_item(cache_id, cache_key, buf, options);
+    }
     --_concurrent_writes;
     STAR_VLOG << "set cache finish, cache_key: " << cache_key << ", status: " << st.error_str();
     return st;
 }
 
 Status StarCacheImpl::_write_cache_item(const CacheId& cache_id, const CacheKey& cache_key, const IOBuf& buf,
-                                        uint64_t ttl_seconds) {
+                                        WriteOptions* options) {
     size_t block_size = config::FLAGS_block_size;
     size_t block_count = (buf.size() - 1) / block_size + 1;
-    uint64_t expire_time = butil::monotonic_time_s() + ttl_seconds;
+    uint64_t expire_time = butil::monotonic_time_s() + (options ? options->ttl_seconds : 0);
     CacheItemPtr cache_item = _alloc_cache_item(cache_key, buf.size(), expire_time);
+    if (options && options->pinned) {
+        cache_item->set_pinned(true);
+    }
 
     uint32_t start_block_index = 0;
     uint32_t end_block_index = (buf.size() - 1) / block_size;
@@ -122,17 +135,18 @@ Status StarCacheImpl::_write_cache_item(const CacheId& cache_id, const CacheKey&
         } else {
             seg_buf = buf;
         }
-        RETURN_IF_ERROR(_write_block(cache_item, block_key, seg_buf));
+        RETURN_IF_ERROR(_write_block(cache_item, block_key, seg_buf, options));
     }
 
     _access_index->insert(cache_id, cache_item);
     return Status::OK();
 }
 
-Status StarCacheImpl::_write_block(CacheItemPtr cache_item, const BlockKey& block_key, const IOBuf& buf) {
+Status StarCacheImpl::_write_block(CacheItemPtr cache_item, const BlockKey& block_key, const IOBuf& buf,
+                                   WriteOptions* options) {
     BlockItem& block = cache_item->blocks[block_key.block_index];
     auto wlck = block_unique_lock(block_key);
-    auto location = _promotion_policy->check_write(cache_item, block_key);
+    auto location = _promotion_policy->check_write(cache_item, block_key, options);
 
     STAR_VLOG << "write block to " << location << ", cache_key: " << cache_item->cache_key
               << ", block_key: " << block_key << ", buf size: " << buf.size();
@@ -159,7 +173,9 @@ Status StarCacheImpl::_write_block(CacheItemPtr cache_item, const BlockKey& bloc
         auto mem_block = _mem_cache->new_block_item(block_key, BlockState::DIRTY, true);
         RETURN_IF_ERROR(_mem_cache->write_block(block_key, mem_block, {segment}));
         block.set_mem_block(mem_block, &wlck);
-        _mem_cache->evict_track(block_key, cache_item->block_size(block_key.block_index));
+        if (!options || !options->pinned || has_disk_layer()) {
+            _mem_cache->evict_track(block_key, cache_item->block_size(block_key.block_index));
+        }
     } else if (location == BlockLocation::DISK) {
         // allocate block and evict
         auto disk_block = _alloc_disk_block(block_key);
@@ -170,8 +186,9 @@ Status StarCacheImpl::_write_block(CacheItemPtr cache_item, const BlockKey& bloc
         RETURN_IF_ERROR(_disk_cache->write_block(block_key.cache_id, disk_block, segment));
 
         block.set_disk_block(disk_block, &wlck);
-        // If the cache has been added to eviction component before, the `add` operation will do nothing.
-        _disk_cache->evict_track(block_key.cache_id, cache_item->size);
+        if (!options || !options->pinned) {
+            _disk_cache->evict_track(block_key.cache_id, cache_item->size);
+        }
 
     } else {
         LOG(ERROR) << "write block is rejected for overload, cache_key: " << cache_item->cache_key
@@ -182,40 +199,41 @@ Status StarCacheImpl::_write_block(CacheItemPtr cache_item, const BlockKey& bloc
     return Status::OK();
 }
 
-Status StarCacheImpl::get(const CacheKey& cache_key, IOBuf* buf) {
+Status StarCacheImpl::get(const CacheKey& cache_key, IOBuf* buf, ReadOptions* options) {
     STAR_VLOG << "get cache, cache_key: " << cache_key;
+    if (options) {
+        STAR_VLOG << " options: " << options;
+    }
     auto cache_id = cachekey2id(cache_key);
     auto cache_item = _access_index->find(cache_id);
-    if (!cache_item || cache_item->cache_key != cache_key) {
+    if (!cache_item || cache_item->cache_key != cache_key || cache_item->is_released()) {
         return Status(ENOENT, "The target not found");
     }
-    if (cache_item->is_released()) {
-        return Status(E_INTERNAL, "the object is released");
-    }
-    Status st = _read_cache_item(cache_id, cache_item, 0, cache_item->size, buf);
+    Status st = _read_cache_item(cache_id, cache_item, 0, cache_item->size, buf, options);
     STAR_VLOG << "get cache finish, cache_key: " << cache_key << ", buf_size: " << buf->size()
               << ", status: " << st.error_str();
     return st;
 }
 
-Status StarCacheImpl::read(const CacheKey& cache_key, off_t offset, size_t size, IOBuf* buf) {
+Status StarCacheImpl::read(const CacheKey& cache_key, off_t offset, size_t size, IOBuf* buf,
+                           ReadOptions* options) {
     STAR_VLOG << "read cache, cache_key: " << cache_key << ", offset: " << offset << ", size: " << size;
+    if (options) {
+        STAR_VLOG << " options: " << options;
+    }
     auto cache_id = cachekey2id(cache_key);
     auto cache_item = _access_index->find(cache_id);
-    if (!cache_item || cache_item->cache_key != cache_key) {
+    if (!cache_item || cache_item->cache_key != cache_key || cache_item->is_released()) {
         return Status(ENOENT, "The target not found");
     }
-    if (cache_item->is_released()) {
-        return Status(E_INTERNAL, "the object is released");
-    }
-    Status st =  _read_cache_item(cache_id, cache_item, offset, size, buf);
+    Status st =  _read_cache_item(cache_id, cache_item, offset, size, buf, options);
     STAR_VLOG << "read cache finish, cache_key: " << cache_key << ", offset:" << offset << ", size: " << size
               << ", buf_size: " << buf->size() << ", status: " << st.error_str();
     return st;
 }
 
 Status StarCacheImpl::_read_cache_item(const CacheId& cache_id, CacheItemPtr cache_item, off_t offset, size_t size,
-                                   IOBuf* buf) {
+                                       IOBuf* buf, ReadOptions* options) {
     buf->clear();
     if (offset + size > cache_item->size) {
         size = offset >= cache_item->size ? 0 : cache_item->size - offset;
@@ -241,7 +259,7 @@ Status StarCacheImpl::_read_cache_item(const CacheId& cache_id, CacheItemPtr cac
         off_t off_in_block = i == start_block_index ? lower - block_lower(i) : 0;
         size_t to_read = i == end_block_index ? upper - (block_lower(i) + off_in_block) + 1
                                               : config::FLAGS_block_size - off_in_block;
-        RETURN_IF_ERROR(_read_block(cache_item, {cache_id, i}, off_in_block, to_read, &block_buf));
+        RETURN_IF_ERROR(_read_block(cache_item, {cache_id, i}, off_in_block, to_read, &block_buf, options));
         aligned_size -= to_read;
         buf->append(block_buf);
     }
@@ -254,7 +272,7 @@ Status StarCacheImpl::_read_cache_item(const CacheId& cache_id, CacheItemPtr cac
 }
 
 Status StarCacheImpl::_read_block(CacheItemPtr cache_item, const BlockKey& block_key, off_t offset, size_t size,
-                              IOBuf* buf) {
+                                  IOBuf* buf, ReadOptions* options) {
     BlockItem& block = cache_item->blocks[block_key.block_index];
     std::vector<BlockSegment> segments;
     std::vector<BlockSegment> disk_segments;
@@ -291,7 +309,7 @@ Status StarCacheImpl::_read_block(CacheItemPtr cache_item, const BlockKey& block
     }
 
     // TODO: The follow procedure can be done asynchronously
-    if (!disk_segments.empty() && _promotion_policy->check_promote(cache_item, block_key)) {
+    if (!disk_segments.empty() && _promotion_policy->check_promote(cache_item, block_key, options)) {
         _promote_block_segments(cache_item, block_key, disk_segments);
     }
     return Status::OK();
@@ -331,15 +349,12 @@ void StarCacheImpl::_remove_cache_item(const CacheId& cache_id, CacheItemPtr cac
     _disk_cache->evict_untrack(cache_id);
 }
 
-Status StarCacheImpl::pin(const std::string& cache_key) {
+Status StarCacheImpl::pin(const CacheKey& cache_key) {
     STAR_VLOG << "pin cache, cache_key: " << cache_key;
     auto cache_id = cachekey2id(cache_key);
     auto cache_item = _access_index->find(cache_id);
-    if (!cache_item || cache_item->cache_key != cache_key) {
+    if (!cache_item || cache_item->cache_key != cache_key || cache_item->is_released()) {
         return Status(ENOENT, "The target not found");
-    }
-    if (cache_item->is_released()) {
-        return Status(E_INTERNAL, "the object is released");
     }
     Status st = _pin_cache_item(cache_id, cache_item);
     STAR_VLOG << "pin cache finish, cache_key: " << cache_key << ", status: " << st.error_str();
@@ -364,15 +379,12 @@ Status StarCacheImpl::_pin_cache_item(const CacheId& cache_id, CacheItemPtr cach
     return Status::OK();
 }
 
-Status StarCacheImpl::unpin(const std::string& cache_key) {
+Status StarCacheImpl::unpin(const CacheKey& cache_key) {
     STAR_VLOG << "unpin cache, cache_key: " << cache_key;
     auto cache_id = cachekey2id(cache_key);
     auto cache_item = _access_index->find(cache_id);
-    if (!cache_item || cache_item->cache_key != cache_key) {
+    if (!cache_item || cache_item->cache_key != cache_key || cache_item->is_released()) {
         return Status(ENOENT, "The target not found");
-    }
-    if (cache_item->is_released()) {
-        return Status(E_INTERNAL, "the object is released");
     }
     Status st = _unpin_cache_item(cache_id, cache_item);
     STAR_VLOG << "unpin cache finish, cache_key: " << cache_key << ", status: " << st.error_str();

--- a/src/star_cache_impl.h
+++ b/src/star_cache_impl.h
@@ -32,17 +32,17 @@ public:
 
     const CacheOptions* options();
 
-    Status set(const std::string& cache_key, const IOBuf& buf, uint64_t ttl_seconds);
+    Status set(const CacheKey& cache_key, const IOBuf& buf, WriteOptions* options);
 
-    Status get(const std::string& cache_key, IOBuf* buf);
+    Status get(const CacheKey& cache_key, IOBuf* buf, ReadOptions* options);
 
-    Status read(const std::string& cache_key, off_t offset, size_t size, IOBuf* buf);
+    Status read(const CacheKey& cache_key, off_t offset, size_t size, IOBuf* buf, ReadOptions* options);
 
-    Status remove(const std::string& cache_key);
+    Status remove(const CacheKey& cache_key);
 
-    Status pin(const std::string& cache_key);
+    Status pin(const CacheKey& cache_key);
 
-    Status unpin(const std::string& cache_key);
+    Status unpin(const CacheKey& cache_key);
 
     bool has_disk_layer() {
         STATIC_EXCEPT_UT bool has_disk = _options.disk_dir_spaces.size() > 0;
@@ -53,14 +53,16 @@ private:
     static size_t _continuous_segments_size(const std::vector<BlockSegmentPtr>& segments);
 
     Status _write_cache_item(const CacheId& cache_id, const CacheKey& cache_key, const IOBuf& buf,
-                             uint64_t ttl_seconds);
-    Status _read_cache_item(const CacheId& cache_id, CacheItemPtr cache_item, off_t offset, size_t size, IOBuf* buf);
+                             WriteOptions* options);
+    Status _read_cache_item(const CacheId& cache_id, CacheItemPtr cache_item, off_t offset, size_t size, IOBuf* buf,
+                            ReadOptions* options);
     void _remove_cache_item(const CacheId& cache_id, CacheItemPtr cache_item);
     Status _pin_cache_item(const CacheId& cache_id, CacheItemPtr cache_item);
     Status _unpin_cache_item(const CacheId& cache_id, CacheItemPtr cache_item);
 
-    Status _write_block(CacheItemPtr cache_item, const BlockKey& block_key, const IOBuf& buf);
-    Status _read_block(CacheItemPtr cache_item, const BlockKey& block_key, off_t offset, size_t size, IOBuf* buf);
+    Status _write_block(CacheItemPtr cache_item, const BlockKey& block_key, const IOBuf& buf, WriteOptions* options);
+    Status _read_block(CacheItemPtr cache_item, const BlockKey& block_key, off_t offset, size_t size, IOBuf* buf,
+                       ReadOptions* options);
 
     Status _flush_block(CacheItemPtr cache_item, const BlockKey& block_key);
     Status _flush_block_segments(CacheItemPtr cache_item, const BlockKey& block_key,
@@ -74,7 +76,7 @@ private:
     void _process_evicted_mem_blocks(const std::vector<BlockKey>& evicted);
     void _process_evicted_disk_items(const std::vector<CacheId>& evicted);
 
-    CacheItemPtr _alloc_cache_item(const std::string& cache_key, size_t size, uint64_t expire_time);
+    CacheItemPtr _alloc_cache_item(const CacheKey& cache_key, size_t size, uint64_t expire_time);
     BlockSegmentPtr _alloc_block_segment(const BlockKey& block_key, off_t offset, uint32_t size, const IOBuf& buf);
     DiskBlockPtr _alloc_disk_block(const BlockKey& block_key);
 

--- a/test/star_cache_test.cpp
+++ b/test/star_cache_test.cpp
@@ -601,6 +601,86 @@ TEST_F(StarCacheTest, pin_unpin_for_hybrid_cache) {
     ASSERT_EQ(st.error_code(), ENOENT) << st.error_str();
 }
 
+TEST_F(StarCacheTest, write_options_with_pinned) {
+    CONFIG_UPDATE(uint32_t, config::FLAGS_lru_container_shard_bits, 0);
+    auto cache = create_simple_cache(10 * MB, 10 * MB);
+
+    const size_t obj_size = 4 * MB + 123;
+    const size_t rounds = 10;
+    const std::string cache_key = "test_file";
+    char ch = 'a';
+    IOBuf wbuf = gen_iobuf(obj_size, ch);
+    Status st;
+
+    WriteOptions options;
+    options.pinned = true;
+    const std::string target_to_pin = cache_key + std::to_string(0);
+    st = cache->set(target_to_pin, wbuf, &options);
+    ASSERT_TRUE(st.ok()) << st.error_str();
+
+    IOBuf rbuf;
+    for (size_t i = 1; i < rounds; ++i) {
+        const std::string key = cache_key + std::to_string(i);
+        st = cache->set(key, wbuf);
+        ASSERT_TRUE(st.ok()) << st.error_str();
+        cache->get(key, &rbuf);
+    }
+
+    st = cache->get(target_to_pin, &rbuf);
+    ASSERT_TRUE(st.ok()) << st.error_str();
+    ASSERT_EQ(rbuf, wbuf);
+
+    // unpin cache
+    st = cache->unpin(target_to_pin);
+    ASSERT_TRUE(st.ok()) << st.error_str();
+
+    for (size_t i = 1; i < rounds; ++i) {
+        const std::string key = cache_key + std::to_string(i);
+        st = cache->set(key, wbuf);
+        ASSERT_TRUE(st.ok()) << st.error_str();
+        cache->get(key, &rbuf);
+    }
+
+    st = cache->get(target_to_pin, &rbuf);
+    ASSERT_EQ(st.error_code(), ENOENT) << st.error_str();
+}
+
+TEST_F(StarCacheTest, write_options_with_overwrite) {
+    CONFIG_UPDATE(uint32_t, config::FLAGS_lru_container_shard_bits, 0);
+    auto cache = create_simple_cache(10 * MB, 10 * MB);
+
+    const size_t obj_size = 4 * MB + 123;
+    const std::string cache_key = "test_file0";
+    IOBuf wbuf = gen_iobuf(obj_size, 'a');
+    Status st;
+    IOBuf rbuf;
+
+    st = cache->set(cache_key, wbuf);
+    ASSERT_TRUE(st.ok()) << st.error_str();
+    st = cache->get(cache_key, &rbuf);
+    ASSERT_TRUE(st.ok()) << st.error_str();
+    ASSERT_EQ(rbuf, wbuf);
+
+    IOBuf wbuf2 = gen_iobuf(obj_size, 'b');
+    st = cache->set(cache_key, wbuf2);
+    ASSERT_TRUE(st.ok()) << st.error_str();
+    st = cache->get(cache_key, &rbuf);
+    ASSERT_TRUE(st.ok()) << st.error_str();
+    ASSERT_EQ(rbuf, wbuf2);
+
+    WriteOptions options;
+    options.overrite = true;
+    st = cache->set(cache_key, wbuf, &options);
+    ASSERT_TRUE(st.ok()) << st.error_str();
+    st = cache->get(cache_key, &rbuf);
+    ASSERT_TRUE(st.ok()) << st.error_str();
+    ASSERT_EQ(rbuf, wbuf);
+
+    options.overrite = false;
+    st = cache->set(cache_key, wbuf2, &options);
+    ASSERT_EQ(st.error_code(), EEXIST) << st.error_str();
+}
+
 } // namespace starrocks::starcache
 
 int main(int argc, char** argv) {

--- a/test/star_cache_test.cpp
+++ b/test/star_cache_test.cpp
@@ -470,44 +470,32 @@ TEST_F(StarCacheTest, cache_with_multi_disk) {
     }
 }
 
-TEST_F(StarCacheTest, replace_cache_content) {
+TEST_F(StarCacheTest, only_cache_in_disk) {
     CONFIG_UPDATE(uint32_t, config::FLAGS_lru_container_shard_bits, 0);
+    // To make sure all flush process will be skipped
+    CONFIG_UPDATE(uint32_t, config::FLAGS_promotion_probalility, 0);
+    CONFIG_UPDATE(uint64_t, config::FLAGS_promotion_mem_threshold, 0);
+    auto cache = create_simple_cache(10 * MB, 25 * MB);
 
-    std::filesystem::create_directories("./ut_dir/star_disk_cache2");
-    std::filesystem::create_directories("./ut_dir/star_disk_cache3");
-
-    std::shared_ptr<StarCache> cache(new StarCache);
-    CacheOptions options;
-    options.mem_quota_bytes = 10 * MB;
-    options.disk_dir_spaces.push_back({.path = "./ut_dir/star_disk_cache", .quota_bytes = 8 * MB});
-    options.disk_dir_spaces.push_back({.path = "./ut_dir/star_disk_cache2", .quota_bytes = 16 * MB});
-    options.disk_dir_spaces.push_back({.path = "./ut_dir/star_disk_cache3", .quota_bytes = 24 * MB});
-    Status status = cache->init(options);
-    ASSERT_TRUE(status.ok());
-
-    const size_t obj_size = 4 * MB;
+    const size_t obj_size = 4 * MB + 123;
     const size_t rounds = 5;
-    const size_t batch_count = 3;
     const std::string cache_key = "test_file";
+    char ch = 'a';
+    IOBuf wbuf = gen_iobuf(obj_size, ch);
     Status st;
 
+    // write cache
     for (size_t i = 0; i < rounds; ++i) {
-        for (size_t j = 0; j < batch_count; ++j) {
-            size_t index = i * batch_count + j;
-            char ch = 'a' + index;
-            IOBuf wbuf = gen_iobuf(obj_size, ch);
-            st = cache->set(cache_key + std::to_string(index), wbuf);
-            ASSERT_TRUE(st.ok()) << st.error_str();
-        }
-        for (size_t j = 0; j < batch_count; ++j) {
-            size_t index = i * batch_count + j;
-            char ch = 'a' + index;
-            IOBuf rbuf;
-            IOBuf expect_buf = gen_iobuf(obj_size, ch);
-            st = cache->get(cache_key + std::to_string(index), &rbuf);
-            ASSERT_TRUE(st.ok()) << st.error_str();
-            ASSERT_EQ(rbuf, expect_buf);
-        }
+        st = cache->set(cache_key + std::to_string(i), wbuf);
+        ASSERT_TRUE(st.ok()) << st.error_str();
+    }
+
+    IOBuf rbuf;
+    IOBuf expect_buf = gen_iobuf(obj_size, ch);
+    for (size_t i = 0; i < rounds; ++i) {
+        st = cache->get(cache_key + std::to_string(i), &rbuf);
+        ASSERT_TRUE(st.ok()) << st.error_str();
+        ASSERT_EQ(rbuf, expect_buf);
     }
 }
 


### PR DESCRIPTION
In this PR, we add write options and read options to api to support more user custom options for each request.

With the write options, we support the following write parameters:
* pinned
* write mode
* overwrite

With the read options, now it only contains the read mode parameter.