### PR TITLE
[Enhancement] Some optimizations for build scripts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     endif()
 endif()
 
-option(WITH_TESTS "Build the starcache test" ON)
-option(WITH_TOOLS "Build the starcache tools" ON)
+option(WITH_TESTS "Build the starcache test" OFF)
+option(WITH_TOOLS "Build the starcache tools" OFF)
 option(WITH_COVERAGE "Enable code coverage build" OFF)
 
 # set CMAKE_BUILD_TYPE
@@ -69,35 +69,58 @@ SET(CMAKE_CXX_FLAGS "${CXX_COMMON_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 message(STATUS "Compiler Flags: ${CMAKE_CXX_FLAGS}")
 
+if ("${STARCACHE_INSTALL_DIR}" STREQUAL "")
+    set(STARCACHE_INSTALL_DIR ${CMAKE_CURRENT_LIST_DIR}/installed)
+endif()
+set(CMAKE_INSTALL_PREFIX ${STARCACHE_INSTALL_DIR})
+set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib)
+set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_PREFIX}/include)
+
 #### External Dependencies ####
 
-FUNCTION(SEARCH_LIBRARY RESULT LIB_NAME)
-    find_library(${RESULT} ${LIB_NAME} ${thirdparty_DIR}/lib)
-    if(NOT ${RESULT})
-        find_library(${RESULT} ${LIB_NAME} ${thirdparty_DIR}/lib64)
+FUNCTION(SEARCH_LIBRARY RESULT LIB_NAME LIB_ROOT)
+    if ("${LIB_ROOT}" STREQUAL "")
+        set(SEARCH_PATH ${STARCACHE_THIRDPARTY_DIR})
+    else()
+        set(SEARCH_PATH ${LIB_ROOT})
+    endif()
+
+    find_library(${RESULT} ${LIB_NAME} ${SEARCH_PATH}/lib)
+    if (NOT ${RESULT})
+        find_library(${RESULT} ${LIB_NAME} ${SEARCH_PATH}/lib64)
+    endif()
+
+    if (${RESULT})
+        if ((NOT "${LIB_ROOT}" STREQUAL "") AND (EXISTS "${LIB_ROOT}/include"))
+            include_directories(${LIB_ROOT}/include)
+        endif()
     endif()
 ENDFUNCTION()
 
 ## PROTOBUF
-SEARCH_LIBRARY(PROTOBUF_LIBPROTOBUF protobuf)
+SEARCH_LIBRARY(PROTOBUF_LIBPROTOBUF protobuf "${PROTOBUF_ROOT}")
 
 ## GFLAGS
-SEARCH_LIBRARY(GFLAGS_LIB gflags)
+SEARCH_LIBRARY(GFLAGS_LIB gflags "${GFLAGS_ROOT}")
 
 ## GLOG
-SEARCH_LIBRARY(GLOG_LIB glog)
+SEARCH_LIBRARY(GLOG_LIB glog "${GLOG_ROOT}")
 
 ## BRPC
-SEARCH_LIBRARY(BRPC_LIB brpc)
+SEARCH_LIBRARY(BRPC_LIB brpc "${BRPC_ROOT}")
 
 ## SSL
-SEARCH_LIBRARY(SSL_LIB ssl)
-SEARCH_LIBRARY(CRYPTO_LIB crypto)
+SEARCH_LIBRARY(SSL_LIB ssl "${SSL_ROOT}")
+SEARCH_LIBRARY(CRYPTO_LIB crypto "${SSL_ROOT}")
 
 ## FMT
-SEARCH_LIBRARY(FMT_LIB fmt)
+SEARCH_LIBRARY(FMT_LIB fmt "${FMT_ROOT}")
 
 ## BOOST
+if ("${BOOST_ROOT}" STREQUAL "")
+    set(BOOST_ROOT ${STARCACHE_THIRDPARTY_DIR})
+endif()
+
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_STATIC_RUNTIME ON)
 set(Boost_DEBUG FALSE)
@@ -113,14 +136,15 @@ include_directories(${Boost_INCLUDE_DIRS})
 set(BOOST_LIB ${Boost_LIBRARIES})
 
 ## include third_party/include
-include_directories(${thirdparty_DIR/include})
+message(STATUS "STARCACHE_THIRDPARTY_DIR: ${STARCACHE_THIRDPARTY_DIR}")
+include_directories(${STARCACHE_THIRDPARTY_DIR}/include)
 
 #### STARCACHE PROJECT ####
 ## GLOBAL VARAIBLES
 set(STARCACHE_SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
 set(STARCACHE_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/test)
 
-include_directories(${STARCACHE_SRC_DIR})
+include_directories(BEFORE ${STARCACHE_SRC_DIR})
 
 ## Common
 set(STARCACHE_COMMON_SRCS
@@ -168,7 +192,6 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "ASAN")
     set(STARCACHE_BASIC_LIBS "${STARCACHE_BASIC_LIBS} -static-libasan")
 endif()
 
-
 target_link_libraries(starcache
     -Wl,--start-group
     ${STARCACHE_BASIC_LIBS}
@@ -206,11 +229,8 @@ if(WITH_TESTS)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
     endif()
     unset(CXX_INCLUDES)
-    find_package(GTest CONFIG REQUIRED)
-    get_target_property(GTest_INCLUDE_DIR GTest::gtest_main INTERFACE_INCLUDE_DIRECTORIES)
-    message(STATUS "Using GTest version: ${GTest_VERSION}")
-    message(STATUS "  include: ${GTest_INCLUDE_DIR}")
-    include_directories(${GTest_INCLUDE_DIR})
+
+    SEARCH_LIBRARY(GTEST_LIB gtest "${GTEST_ROOT}")
 
     # TEST LIBRARY
     set(STARCACHE_TEST_SRCS
@@ -224,7 +244,7 @@ if(WITH_TESTS)
 
     target_link_libraries(starcache_test
         starcache
-        GTest::gtest_main
+        ${GTEST_LIB}
     )
 endif()
 

--- a/build-scripts/cmake-build.sh
+++ b/build-scripts/cmake-build.sh
@@ -151,9 +151,6 @@ if [ -z "${STARCACHE_INSTALL_DIR}" ] ; then
     STARCACHE_INSTALL_DIR=$INSTALL_DIR_PREFIX/starcache_installed
 fi
 
-mkdir -p ${CMAKE_BUILD_DIR}
-mkdir -p ${STARCACHE_INSTALL_DIR}
-
 if [ ${CLEAN} -eq 1  ]; then
     rm -rf ${CMAKE_BUILD_DIR}
 fi
@@ -162,19 +159,23 @@ mkdir -p ${CMAKE_BUILD_DIR}
 mkdir -p ${STARCACHE_INSTALL_DIR}
 
 $STARCACHE_CMAKE_CMD -B ${CMAKE_BUILD_DIR} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache                 \
-	  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} 													\
-	  -DWITH_TESTS=${WITH_TESTS} 																\
-	  -DWITH_TOOLS=${WITH_TOOLS} 																\
-	  -DWITH_COVERAGE=OFF																		\
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}                                                    \
+      -DWITH_TESTS=${WITH_TESTS}                                                                \
+      -DWITH_TOOLS=${WITH_TOOLS}                                                                \
+      -DWITH_COVERAGE=OFF                                                                       \
       -DOPENSSL_USE_STATIC_LIBS=TRUE                                                            \
-      -DGTest_DIR=${THIRD_PARTY_INSTALL_PREFIX}/lib/cmake/GTest                                 \
-      -DBOOST_ROOT=${THIRD_PARTY_INSTALL_PREFIX}                                                \
-      -Dthirdparty_DIR=${THIRD_PARTY_INSTALL_PREFIX}/                                           \
+      -DSTARCACHE_THIRDPARTY_DIR=${THIRD_PARTY_INSTALL_PREFIX}/                                 \
+      -DSTARCACHE_INSTALL_DIR=${STARCACHE_INSTALL_DIR}                                          \
+      -DPROTOBUF_ROOT=${WITH_PROTOBUF_ROOT}                                                     \
+      -DGFLAGS_ROOT=${WITH_GFLAGS_ROOT}                                                         \
+      -DGLOG_ROOT=${WITH_GLOG_ROOT}                                                             \
+      -DBRPC_ROOT=${WITH_BRPC_ROOT}                                                             \
+      -DSSL_ROOT=${WITH_SSL_ROOT}                                                               \
+      -DFMT_ROOT=${WITH_FMT_ROOT}                                                               \
+      -DGTEST_ROOT=${WITH_GTEST_ROOT}                                                           \
+      -DBOOST_ROOT=${WITH_BOOST_ROOT}                                                           \
       ${STARCACHE_TEST_COVERAGE:+"-Dstarcache_BUILD_COVERAGE=$STARCACHE_TEST_COVERAGE"}         \
-      -DCMAKE_INSTALL_PREFIX=${STARCACHE_INSTALL_DIR}                                           \
       .
-
-      #-DBoost_LIBRARYDIR=${THIRD_PARTY_INSTALL_PREFIX}/lib                                     \
 
 cd ${CMAKE_BUILD_DIR}
 echo make -j $PARALLEL

--- a/src/block_item.h
+++ b/src/block_item.h
@@ -16,6 +16,7 @@
 
 #include <butil/iobuf.h>
 
+#include <mutex>
 #include <shared_mutex>
 
 #include "aux_funcs.h"

--- a/src/disk_space_manager.h
+++ b/src/disk_space_manager.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <boost/dynamic_bitset.hpp>
+#include <mutex>
 #include <shared_mutex>
 
 #include "aux_funcs.h"


### PR DESCRIPTION
This PR add some optimizations for build scripts:
- Set the `CMAKE_INSTALL_LIBDIR` to `lib` instead of default library path, to avoid the different value in centos and ubuntu.
- Support pass library root parameter to receive a single custom library search path.