### PR TITLE
[Enhancement] Remove block_size and checksum from cache options because they can be configured with gflags directly.

### DIFF
--- a/src/common/types.h
+++ b/src/common/types.h
@@ -62,10 +62,6 @@ struct CacheOptions {
     AdmissionCtrlPolicy admission_ctrl_policy;
     PromotionPolicy promotion_policy;
     */
-
-    // Other (Optional)
-    bool checksum = false;
-    size_t block_size = 0;
 };
 
 struct WriteOptions {

--- a/src/star_cache_impl.cpp
+++ b/src/star_cache_impl.cpp
@@ -41,13 +41,6 @@ StarCacheImpl::~StarCacheImpl() {
 
 Status StarCacheImpl::init(const CacheOptions& options) {
     _options = options;
-    if (options.block_size > 0) {
-        config::FLAGS_block_size = options.block_size;
-    } else {
-        _options.block_size = config::FLAGS_block_size;
-    }
-    config::FLAGS_enable_disk_checksum = options.checksum;
-
     MemCacheOptions mc_options;
     mc_options.mem_quota_bytes = options.mem_quota_bytes;
     RETURN_IF_ERROR(_mem_cache->init(mc_options));


### PR DESCRIPTION
Now, the `block_size` and `checksum` both are global configurations and can be configured with gflags file directly. So, we remove them from cache options to avoid the configuration confusion.