### PR TITLE
[BugFix] Check the return value of `posix_memalign` before using the aligned buffer.

### DIFF
--- a/src/aux_funcs.cpp
+++ b/src/aux_funcs.cpp
@@ -25,7 +25,9 @@ uint64_t cachekey2id(const std::string& key) {
 size_t align_iobuf(const butil::IOBuf& buf, void** aligned_data) {
     size_t aligned_unit = config::FLAGS_io_align_unit_size;
     size_t aligned_size = round_up(buf.size(), aligned_unit);
-    posix_memalign(aligned_data, aligned_unit, aligned_size);
+    if (posix_memalign(aligned_data, aligned_unit, aligned_size) != 0) {
+        return 0;
+    }
 
     butil::IOBuf tmp_buf(buf);
     // IOBufCutter is a specialized utility to cut from IOBuf faster than using corresponding

--- a/src/cache_item.h
+++ b/src/cache_item.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <atomic>
+#include <mutex>
 #include <shared_mutex>
 
 #include "block_item.h"

--- a/src/mem_space_manager.h
+++ b/src/mem_space_manager.h
@@ -18,6 +18,7 @@
 #include <butil/memory/singleton.h>
 
 #include <atomic>
+#include <mutex>
 #include <shared_mutex>
 
 namespace starrocks::starcache {

--- a/src/sharded_lock_manager.h
+++ b/src/sharded_lock_manager.h
@@ -16,6 +16,7 @@
 
 #include <butil/memory/singleton.h>
 
+#include <mutex>
 #include <shared_mutex>
 
 #include "aux_funcs.h"

--- a/src/star_cache_impl.cpp
+++ b/src/star_cache_impl.cpp
@@ -151,6 +151,10 @@ Status StarCacheImpl::_write_block(CacheItemPtr cache_item, const BlockKey& bloc
             // We allocate an aligned buffer here to avoid repeatedlly copying data to a new aligned buffer
             // when flush to disk file in `O_DIRECT` mode.
             size = align_iobuf(buf, &data);
+            if (size == 0) {
+                LOG(ERROR) << "align io buffer failed when write block";
+                return Status(ENOMEM, "align io buffer failed");
+            }
         } else {
             data = malloc(buf.size());
             buf.copy_to(data);

--- a/src/tools/starcache_tester.cpp
+++ b/src/tools/starcache_tester.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <numeric>
 #include <thread>
+#include <mutex>
 #include <shared_mutex>
 
 #include "star_cache.h"


### PR DESCRIPTION
In this PR, we check the return value of `posix_memalign` before using the aligned buffer. On the one hand, it can avoid the `-Wunused-result` warning in some compiles, on the other hand, it helps avoid some unexpected error caused by posix memory operations.

Also, we add the mutex header files to some source files in case of the undefined `unique_lock` for some special build environment.