### PR TITLE
[Enhancement] Add a `STARCACHE_SKIP_INSTALL` build option to enable skipping the installation in some cases.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,11 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     endif()
 endif()
 
-option(WITH_TESTS "Build the starcache test" OFF)
-option(WITH_TOOLS "Build the starcache tools" OFF)
+option(STARCACHE_WITH_TESTS "Build the starcache tests" OFF)
+option(STARCACHE_WITH_TOOLS "Build the starcache tools" OFF)
 option(WITH_COVERAGE "Enable code coverage build" OFF)
-option(FIND_DEFAULT_PATH "Whether to find the library in default system library path" OFF)
+option(STARCACHE_FIND_DEFAULT_PATH "Whether to find the library in default system library path" OFF)
+option(STARCACHE_SKIP_INSTALL "Skip installing the output files after building the starcache" OFF)
 
 # set CMAKE_BUILD_TYPE
 if (NOT CMAKE_BUILD_TYPE)
@@ -85,13 +86,13 @@ set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_PREFIX}/include)
 #### External Dependencies ####
 
 FUNCTION(FIND_LIBRARY_IN_PATH RESULT LIB_FILE LIB_NAME LIB_PATH)
-    if(FIND_DEFAULT_PATH)
+    if(STARCACHE_FIND_DEFAULT_PATH)
         find_library(${RESULT} NAMES ${LIB_FILE} ${LIB_NAME} PATHS ${LIB_PATH}/lib)
     else()
         find_library(${RESULT} NAMES ${LIB_FILE} ${LIB_NAME} PATHS ${LIB_PATH}/lib NO_DEFAULT_PATH)
     endif()
     if (NOT ${RESULT})
-        if(FIND_DEFAULT_PATH)
+        if(STARCACHE_FIND_DEFAULT_PATH)
             find_library(${RESULT} NAMES ${LIB_FILE} ${LIB_NAME} PATHS ${LIB_PATH}/lib64)
         else()
             find_library(${RESULT} NAMES ${LIB_FILE} ${LIB_NAME} PATHS ${LIB_PATH}/lib64 NO_DEFAULT_PATH)
@@ -106,7 +107,11 @@ FUNCTION(SEARCH_LIBRARY RESULT LIB_FILE LIB_NAME LIB_ROOT)
         set(SEARCH_PATH ${LIB_ROOT})
     endif()
 
-    FIND_LIBRARY_IN_PATH(${RESULT} ${LIB_FILE} ${LIB_NAME} ${SEARCH_PATH})
+    if ("${SEARCH_PATH}" STREQUAL "")
+        message(ERROR " The 'STARCACHE_THIRDPARTY_DIR' or the ${LIB_NAME} root path need to be set to find the library!")
+    endif()
+
+    FIND_LIBRARY_IN_PATH(${RESULT} ${LIB_FILE} ${LIB_NAME} "${SEARCH_PATH}")
     if (${RESULT})
         message(STATUS "find library ${LIB_NAME}")
         if ((NOT "${LIB_ROOT}" STREQUAL "") AND (EXISTS "${LIB_ROOT}/include"))
@@ -229,7 +234,7 @@ target_link_libraries(starcache
 ### BINARY EXECUTABLE
 
 # tools
-if(WITH_TOOLS)
+if(STARCACHE_WITH_TOOLS)
     set(STARCACHE_TOOLS_SRCS
         ${STARCACHE_SRC_DIR}/tools/starcache_tester.cpp
     )
@@ -239,7 +244,7 @@ endif()
 
 ### TEST SECTION
 
-if(WITH_TESTS)
+if(STARCACHE_WITH_TESTS)
     if(WITH_COVERAGE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
     endif()
@@ -265,41 +270,9 @@ endif()
 
 ### INSTALLATION SECTION
 
-# include CMAKE_INSTALL_INCLUDEDIR definitions
-include(GNUInstallDirs)
+if(STARCACHE_SKIP_INSTALL)
+    message(STATUS "Skip installing starcache build output.")
+else()
+    include(cmake/install.cmake)
+endif()
 
-## install include files
-install(
-    DIRECTORY ${STARCACHE_SRC_DIR}/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/starcache
-    FILES_MATCHING PATTERN "*.h*"
-)
-
-# install libraries
-install(
-    TARGETS ${PROJECT_NAME}
-        starcache
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    EXPORT ${PROJECT_NAME}
-)
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/starcacheConfigVersion.cmake
-    VERSION 0.0.1
-    COMPATIBILITY SameMajorVersion
-)
-
-set(STARCACHE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/starcache)
-
-configure_package_config_file(
-    ${PROJECT_SOURCE_DIR}/cmake/starcacheConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/starcacheConfig.cmake
-    INSTALL_DESTINATION ${STARCACHE_CMAKE_DIR}
-    PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR
-)
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/starcacheConfig.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/starcacheConfigVersion.cmake
-              DESTINATION ${STARCACHE_CMAKE_DIR}
-)

--- a/build-scripts/cmake-build.sh
+++ b/build-scripts/cmake-build.sh
@@ -147,8 +147,16 @@ popd
 
 CMAKE_BUILD_DIR=build/build_${CMAKE_BUILD_TYPE}
 
-if [ -z "${STARCACHE_INSTALL_DIR}" ] ; then
+if [ -z "${STARCACHE_INSTALL_DIR}" ]; then
     STARCACHE_INSTALL_DIR=$INSTALL_DIR_PREFIX/starcache_installed
+fi
+
+if [ -z "${FIND_DEFAULT_PATH}" ]; then
+    FIND_DEFAULT_PATH=OFF
+fi
+
+if [ -z "${SKIP_INSTALL}" ]; then
+    SKIP_INSTALL=OFF
 fi
 
 if [ ${CLEAN} -eq 1  ]; then
@@ -160,12 +168,14 @@ mkdir -p ${STARCACHE_INSTALL_DIR}
 
 $STARCACHE_CMAKE_CMD -B ${CMAKE_BUILD_DIR} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache                 \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}                                                    \
-      -DWITH_TESTS=${WITH_TESTS}                                                                \
-      -DWITH_TOOLS=${WITH_TOOLS}                                                                \
-      -DWITH_COVERAGE=OFF                                                                       \
-      -DOPENSSL_USE_STATIC_LIBS=TRUE                                                            \
+      -DSTARCACHE_WITH_TESTS=${WITH_TESTS}                                                      \
+      -DSTARCACHE_WITH_TOOLS=${WITH_TOOLS}                                                      \
+      -DSTARCACHE_WITH_COVERAGE=OFF                                                             \
+      -DSTARCACHE_FIND_DEFAULT_PATH=${FIND_DEFAULT_PATH}                                        \
+      -DSTARCACHE_SKIP_INSTALL=${SKIP_INSTALL}                                                  \
       -DSTARCACHE_THIRDPARTY_DIR=${THIRD_PARTY_INSTALL_PREFIX}/                                 \
       -DSTARCACHE_INSTALL_DIR=${STARCACHE_INSTALL_DIR}                                          \
+      -DOPENSSL_USE_STATIC_LIBS=TRUE                                                            \
       -DPROTOBUF_ROOT=${WITH_PROTOBUF_ROOT}                                                     \
       -DGFLAGS_ROOT=${WITH_GFLAGS_ROOT}                                                         \
       -DGLOG_ROOT=${WITH_GLOG_ROOT}                                                             \
@@ -174,11 +184,13 @@ $STARCACHE_CMAKE_CMD -B ${CMAKE_BUILD_DIR} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 
       -DFMT_ROOT=${WITH_FMT_ROOT}                                                               \
       -DGTEST_ROOT=${WITH_GTEST_ROOT}                                                           \
       -DBOOST_ROOT=${WITH_BOOST_ROOT}                                                           \
-      -DFIND_DEFAULT_PATH=${FIND_DEFAULT_PATH}                                                  \
       ${STARCACHE_TEST_COVERAGE:+"-Dstarcache_BUILD_COVERAGE=$STARCACHE_TEST_COVERAGE"}         \
       .
 
 cd ${CMAKE_BUILD_DIR}
 echo make -j $PARALLEL
 make -j $PARALLEL
-make install -j $PARALLEL
+
+if [ "${SKIP_INSTALL}" == "OFF" ]; then
+    make install -j $PARALLEL
+fi

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,0 +1,40 @@
+### install the starcache output
+
+# include CMAKE_INSTALL_INCLUDEDIR definitions
+include(GNUInstallDirs)
+
+## install include files
+install(
+    DIRECTORY ${STARCACHE_SRC_DIR}/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/starcache
+    FILES_MATCHING PATTERN "*.h*"
+)
+
+# install libraries
+install(
+    TARGETS ${PROJECT_NAME}
+        starcache
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    EXPORT ${PROJECT_NAME}
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/starcacheConfigVersion.cmake
+    VERSION 0.0.1
+    COMPATIBILITY SameMajorVersion
+)
+
+set(STARCACHE_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/starcache)
+
+configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/cmake/starcacheConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/starcacheConfig.cmake
+    INSTALL_DESTINATION ${STARCACHE_CMAKE_DIR}
+    PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/starcacheConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/starcacheConfigVersion.cmake
+              DESTINATION ${STARCACHE_CMAKE_DIR}
+)

--- a/src/star_cache_impl.cpp
+++ b/src/star_cache_impl.cpp
@@ -609,7 +609,7 @@ void StarCacheImpl::_process_evicted_mem_blocks(const std::vector<BlockKey>& evi
         // the following `find`?
         auto cache_item = _access_index->find(key.cache_id);
         if (!cache_item) {
-            LOG(WARNING) << "block does not exist when evict " << key;
+            LOG(INFO) << "block does not exist when evict " << key;
             continue;
         }
         STAR_VLOG << "evict mem block, cache_key: " << cache_item->cache_key << ", block_key: " << key;


### PR DESCRIPTION
In this PR:
* we add a `STARCACHE_SKIP_INSTALL` build option to enable skipping the installation in some cases. For example, if the starcache is imported as a submodule, we can build it as a subdirectory and the installation is unnecessary.
* Also, we format some variable names in the cmake files to make it easily passed by the upper applications.