### PR TITLE
Fix compile problem

### DIFF
--- a/third_party/build-thirdparty.sh
+++ b/third_party/build-thirdparty.sh
@@ -287,7 +287,7 @@ build_curl()
     local installprefix=$2
 
     pushd $srcdir &>/dev/null
-    LIBS="-lcrypto -lssl -ldl" ./configure --prefix=$installprefix --disable-shared --enable-static \
+    LIBS="-lssl -lcrypto -ldl" ./configure --prefix=$installprefix --disable-shared --enable-static \
             --without-librtmp --with-ssl=${installprefix} --without-libidn2 --without-libgsasl --disable-ldap --enable-ipv6 --without-zstd
     make -j$PARALLEL
     make install


### PR DESCRIPTION
ssl relies on crypto, so put ssl first and then crypto, otherwise may encounter following problem

```
t1_enc.c:(.text+0x30f): undefined reference to `COMP_CTX_free'
/usr/bin/ld: t1_enc.c:(.text+0x328): undefined reference to `COMP_CTX_new'
/usr/bin/ld: t1_enc.c:(.text+0x5ec): undefined reference to `COMP_CTX_free'
/usr/bin/ld: t1_enc.c:(.text+0x605): undefined reference to `COMP_CTX_new'
```